### PR TITLE
(fix) Fix missing reply

### DIFF
--- a/src/commands/season.ts
+++ b/src/commands/season.ts
@@ -36,6 +36,6 @@ export const Season: Command = {
     BotConfig.getInstance().save(config);
     log.info(content);
 
-    await interaction.followUp({ ephemeral: true, content });
+    await interaction.reply({ ephemeral: true, content });
   },
 };


### PR DESCRIPTION
Fixes the issue by using the 'reply' method instead of 'followUp'. Method 'followUp' is for deferred responses.  Default deferred response was removed in v2.0.0.  Closes #1