### PR TITLE
(fix) Allow any text when using 'wb_weather set' command

### DIFF
--- a/src/commands/weather.ts
+++ b/src/commands/weather.ts
@@ -19,9 +19,6 @@ export const UpdateWeather: Command = {
           description: "The weather event",
           type: ApplicationCommandOptionType.String,
           required: true,
-          choices: [
-            { name: "Chaos", value: "Chaos" }
-          ]
         }
       ],
     },


### PR DESCRIPTION
Closes #8